### PR TITLE
🧹 Removed unused style compactMode

### DIFF
--- a/index.macos.js
+++ b/index.macos.js
@@ -347,7 +347,7 @@ export default class XcodeCleaner extends Component {
                 ]}>
                   <View style={styles.rowLeft}>
                     <View style={styles.headerWithBadge}>
-                      <Text style={[styles.name, compactMode ? styles.compactName : null]}>{group.name}</Text>
+                      <Text style={styles.name}>{group.name}</Text>
                       {count ? <Button title={count + ''} bezelStyle='rounded' type='momentaryLight' /> : null}
                     </View>
                     {!compactMode && <Text style={styles.description}>{group.description}</Text> }
@@ -505,10 +505,6 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     height: 20,
     marginBottom: 10,
-  },
-  compactName: {
-    // color: secondaryTextColor,
-    // fontWeight: 'normal',
   },
 });
 


### PR DESCRIPTION
Hi @waylybaye. I recently added XcodeCleaner to my development workflow I'm really impressed with it. If you're up for it, I'd like to help you maintain XcodeCleaner. I'll start with a few small PRs like this one.

## Overview
The style `compactName` wasn't being used, so I removed it.